### PR TITLE
librarySourceHashes

### DIFF
--- a/Sources/MetalBuilder/MetalBuilderRenderer/RenderData.swift
+++ b/Sources/MetalBuilder/MetalBuilderRenderer/RenderData.swift
@@ -22,6 +22,9 @@ struct RenderData{
     
     var context: MetalBuilderRenderingContext!
     
+    //hold hashes for librarySources of BuildingBlocks to eliminate dublicates
+    var librarySourceHashes: [Int] = []
+    
     init(){}
     
     init(from renderingContent: MetalRenderingContent,
@@ -201,8 +204,13 @@ struct RenderData{
                     data.append(blockData)
                 }else{
                     //compile to shared library
-                    librarySource = buildingBlockComponent.librarySource + librarySource
-                    helpers += buildingBlockComponent.helpers
+                    let source = buildingBlockComponent.librarySource
+                    let sourceHash = source.hashValue
+                    if !data.librarySourceHashes.contains(sourceHash){
+                        data.librarySourceHashes.append(sourceHash)
+                        librarySource = source + librarySource
+                        helpers += buildingBlockComponent.helpers
+                    }
                     
                     let blockData = try compile(
                         device: device,
@@ -323,6 +331,8 @@ struct RenderData{
     mutating func append(_ data: RenderData){
         passes.append(contentsOf: data.passes)
         textures.append(contentsOf: data.textures)
+        
+        librarySourceHashes.append(contentsOf: data.librarySourceHashes)
         
         functionsAndArgumentsToAddToMetal
             .append(contentsOf: data.functionsAndArgumentsToAddToMetal)

--- a/Sources/MetalBuilder/MetalResultBuilder/MetalBuildingBlock.swift
+++ b/Sources/MetalBuilder/MetalResultBuilder/MetalBuildingBlock.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 /// Protocol for declaring autonomous building blocks
 ///
-/// if compileOptions are not nil the source will compile into separate library
+/// if compileOptions are not nil the source will compile into separate library (still has issues)
+/// otherwise the contents of `librarySource` will be concatinated to global LibrarySource.
+/// - Important: If two or more BuildingBlocks have identical `librarySource` this source will be added only once.
 public protocol MetalBuildingBlock: MetalBuilderComponent{
     var context: MetalBuilderRenderingContext { get set }
     var helpers: String { get }

--- a/Sources/MetalBuilder/MetalResultBuilder/ResultBuilderComponents/EncodeGroup.swift
+++ b/Sources/MetalBuilder/MetalResultBuilder/ResultBuilderComponents/EncodeGroup.swift
@@ -4,49 +4,48 @@ import SwiftUI
 ///
 /// initializes a group of components
 /// 'repeating' indicates number of subsequent dispatches for the group
-/// the group can have it's own Metal library source code
 public struct EncodeGroup: MetalBuilderComponent{
     
     var repeating: Binding<Int>
     var active: Binding<Bool>
-    public let librarySource: String?
+    //public let librarySource: String?
     @MetalResultBuilder public let metalContent: MetalContent
     
     public init(repeating: MetalBinding<Int>,
                 active: MetalBinding<Bool>,
-                librarySource: String? = nil,
+                //librarySource: String? = nil,
                 @MetalResultBuilder metalContent: ()->MetalContent) {
         self.init(repeating: repeating.binding,
                   active: active.binding,
-                  librarySource: librarySource,
+                  //librarySource: librarySource,
                   metalContent: metalContent)
     }
     
     public init(repeating: Int = 1,
                 active: MetalBinding<Bool>,
-                librarySource: String? = nil,
+                //librarySource: String? = nil,
                 @MetalResultBuilder metalContent: ()->MetalContent) {
         self.init(repeating: Binding<Int>.constant(repeating),
                   active: active.binding,
-                  librarySource: librarySource,
+                  //librarySource: librarySource,
                   metalContent: metalContent)
     }
     
     public init(repeating: Int = 1,
                 active: Binding<Bool> = Binding<Bool>.constant(true),
-                librarySource: String? = nil,
+                //librarySource: String? = nil,
                 @MetalResultBuilder metalContent: ()->MetalContent) {
         self.init(repeating: Binding<Int>.constant(repeating),
                   active: active,
-                  librarySource: librarySource,
+                  //librarySource: librarySource,
                   metalContent: metalContent)
     }
     
     public init(repeating: Binding<Int>,
                 active: Binding<Bool> = Binding<Bool>.constant(true),
-                librarySource: String? = nil,
+                //librarySource: String? = nil,
                 @MetalResultBuilder metalContent: ()->MetalContent) {
-        self.librarySource = librarySource
+        //self.librarySource = librarySource
         self.metalContent = metalContent()
         self.repeating = repeating
         self.active = active


### PR DESCRIPTION
librarySourceHashes in RenderData
to eliminate duplicates in global librarySource when multiple blocks are used in metalContent